### PR TITLE
fix: change default mqtt listener bind address and port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
         MONGO_PORT: 27017
     container_name: thin-edge-setup.io
     expose:
-      - "8883"
+      - "1883"
       - "9080"
     ports:
-      - "8883:8883"
+      - "1883:1883"
       - "9080:9080"
     environment:
       - MONGO_HOST=mongodb1
@@ -41,7 +41,7 @@ services:
         condition: on-failure
     environment:
       - MQTT_BROKER=tedge
-      - MQTT_PORT=8883
+      - MQTT_PORT=1883
       - MONGO_HOST=mongodb1
       - MONGO_PORT=27017
   mongodb:

--- a/node-red/flows.json
+++ b/node-red/flows.json
@@ -9,9 +9,9 @@
     {
         "id": "e9738faf9b0558bb",
         "type": "mqtt-broker",
-        "name": "thin-edge-setup.io",
-        "broker": "thin-edge-setup.io",
-        "port": "8883",
+        "name": "tedge",
+        "broker": "tedge",
+        "port": "1883",
         "clientid": "",
         "autoConnect": true,
         "usetls": false,

--- a/node-red/node-red-setup.sh
+++ b/node-red/node-red-setup.sh
@@ -13,9 +13,9 @@ if [ ! -f /service/node-red-init.flag ]; then
     {
         "id": "e9738faf9b0558bb",
         "type": "mqtt-broker",
-        "name": "thin-edge-setup.io",
-        "broker": "thin-edge-setup.io",
-        "port": "8883",
+        "name": "tedge",
+        "broker": "tedge",
+        "port": "1883",
         "clientid": "",
         "autoConnect": true,
         "usetls": false,

--- a/tedge/backend/thinEdgeBackend.js
+++ b/tedge/backend/thinEdgeBackend.js
@@ -423,11 +423,11 @@ class ThinEdgeBackend {
                 },
                 {
                     cmd: 'sudo',
-                    args: ["tedge", "config", "set", "mqtt.external.port", "8883"]
+                    args: ["tedge", "config", "set", "mqtt.bind.port", "1883"]
                 },
                 {
                     cmd: 'sudo',
-                    args: ["tedge", "config", "set", "mqtt.external.bind_address", "0.0.0.0"]
+                    args: ["tedge", "config", "set", "mqtt.bind.address", "0.0.0.0"]
                 },
                 {
                     cmd: 'sudo',

--- a/tedge/etc/tedge/tedge.toml
+++ b/tedge/etc/tedge/tedge.toml
@@ -1,3 +1,3 @@
-[mqtt]
-external_port = 8883
-external_bind_address = "0.0.0.0"
+[mqtt.bind]
+address = "0.0.0.0"
+port = 1883


### PR DESCRIPTION
Change default MQTT listener bind address and port settings.

* Use port `1883` (as the connection is not encrypted). Using `8883` can mislead users into believing that it is encrypted
* Use single MQTT listener rather than multiple (since we're running in a container anyway)