### PR TITLE
Remove unnecessary trailing backslashes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ docker-compose up
 
 # Configure Thin Edge in the web-ui
 
-To access the web-ui open a web browser at: http://localhost:9080/#/setup.\
-Here you start the setup of the edge and enter external device id and your cumulocity tenant url.\
+To access the web-ui open a web browser at: http://localhost:9080/#/setup.
+Here you start the setup of the edge and enter external device id and your cumulocity tenant url.
 ![Setup](resource/01-Setup.png)
 Then press `Configure Edge` to create a device certificate. This Will late be uploaded to you cloud tenant. The Thin Edge uses the certificate for authentication.
 This will generate a certificate. This has to be uploaded through the web-ui. As mentioned before, the certificate is uploaded to the cloud tenant.
@@ -52,8 +52,8 @@ This will generate a certificate. This has to be uploaded through the web-ui. As
 Alternatively, you can download the certificate locally and upload it manually to your cloud tenant.
 
 ![Setup](resource/05-Setup.png)
-A detailed description how to import your certificate can de found is [Cumulocity Administration Documentation](https://cumulocity.com/guides/users-guide/device-management/#managing-trusted-certificates) to your cumulocity cloud tenant.\
-Download the certificate.\
+A detailed description how to import your certificate can de found is [Cumulocity Administration Documentation](https://cumulocity.com/guides/users-guide/device-management/#managing-trusted-certificates) to your cumulocity cloud tenant.
+Download the certificate.
 When the certificate is uploaded you can start the edge. If everything went well the completion of the startup is acknowledged
 
 ![Setup](resource/01-Control.png)


### PR DESCRIPTION
For some reason there were trailing backslashes on some lines (presumably done to make markdown continue the paragraph). This is not necessary and actually caused the local UI url to not be rendered correctly.